### PR TITLE
keep the path for the proxy request

### DIFF
--- a/pkg/apis/proxy/proxy.go
+++ b/pkg/apis/proxy/proxy.go
@@ -166,6 +166,7 @@ func handleProxyCommon(p *SprayProxy, c *gin.Context) {
 		copy := c.Copy()
 		newURL := copy.Request.URL
 		newURL.Host = backendURL.Host
+		newURL.Path = backendURL.Path
 		newURL.Scheme = backendURL.Scheme
 
 		// zap always append and does not override field entries, so we create


### PR DESCRIPTION
The proxy backend drops the path so if you use a proxy like https:/someURL/api/webhook (like argocd), it will fall to reach the destination as the path is dropped. 

This change adds the path to the proxy request. 
For backends that did not specify a path, its a noop.